### PR TITLE
Capture user stats: active/inactive/total storage (GB)

### DIFF
--- a/web/boxsdk/object/user.py
+++ b/web/boxsdk/object/user.py
@@ -9,3 +9,37 @@ class User(BaseObject):
     """Represents a Box user."""
 
     _item_type = 'user'
+
+    def get_enterprise_users(self, limit=100, offset=0, filter_term=None):
+        """
+        Get enterprise users. Requires an auth token from an enterprise admin account.
+
+        :param limit:
+            The number of records to return. (default=100, max=1000)
+        :type limit:
+            `int`
+        :param offset:
+            The record at which to start.
+        :type offset:
+            `int`
+        :param filter_term:
+            A string used to filter the results to only users starting with the filter_term in either the name or the login.
+        :type event_type:
+            'unicode'        
+        :returns:
+            JSON response from the Box /users endpoint. Returns the list of all users for the Enterprise with their
+            user_id, public_name, and login if the user is an enterprise admin.
+        :rtype:
+            `dict`
+        """
+        url = 'https://api.box.com/2.0/users' #self.get_url()
+        params = {
+            'limit': limit,
+            'offset': offset
+        }
+        
+        if filter_term is not None:
+            params['filter_term'] = filter_term
+        
+        box_response = self._session.get(url, params=params)
+        return box_response.json()

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -25,6 +25,13 @@
         <iframe style="width:100%; height:100%; min-height:320px" src="event/engagement" ></iframe>
     </div>
 </row>
+<row style="margin-top:20px" style="height:30%">
+    <div class="col-md-6">
+        <iframe style="width:100%; height:100%; min-height:320px" src="usage/user" ></iframe>
+    </div>
+    <div class="col-md-6">
+    </div>
+</row>
 
 {% endblock %}
 

--- a/web/templates/usage-user.html
+++ b/web/templates/usage-user.html
@@ -1,0 +1,20 @@
+{% extends "_base.iframe.html" %}
+
+{% block content %}
+
+<div id="chart"></div>
+
+{% endblock %}
+
+{% block js %}
+<script type="text/javascript">
+$(function () {
+    chart.create( '#chart',
+                  300,
+                  'User Stats',
+                  'stat?type=',
+                  ['ACTIVE_USERS', 'INACTIVE_USERS', 'STORAGE_USED_GB'],
+                  ['Active', 'Inactive', 'Storage (GB)']);
+});
+</script>
+{% endblock %}

--- a/web/templates/usage-user.html
+++ b/web/templates/usage-user.html
@@ -11,7 +11,7 @@
 $(function () {
     chart.create( '#chart',
                   300,
-                  'User Stats',
+                  'Usage Stats',
                   'stat?type=',
                   ['ACTIVE_USERS', 'INACTIVE_USERS', 'STORAGE_USED_GB'],
                   ['Active', 'Inactive', 'Storage (GB)']);


### PR DESCRIPTION
User stats will be capture once per hour.

Also added two new URLs for triggering on-demand jobs. No UI elements for these; they're more intended for for testing.

`/event/trigger`
`/usage/trigger`
