### PR TITLE
Use SQL to determine the date/time gaps

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -102,6 +102,11 @@ def event_trigger():
 	tasks.trigger_event_job()
 	return Response(json.dumps("OK"),  mimetype='application/json')
 
+@app.route('/event/backfill', methods=['GET'])
+def event_backfill():
+	tasks.trigger_event_backfill()
+	return Response(json.dumps("OK"),  mimetype='application/json')
+
 @app.before_first_request
 def init():
 	app.logger.debug("Init pid {}".format(os.getpid()))


### PR DESCRIPTION
It seemed that we could ask postgres to do the hard work of determining when date/time gaps existed. I added a query (`sql`) to do that. I then modified `backfill_velocity` to iterate over each gap to fill it. This is a generic approach because we can format the query to target event gaps vs. usage gaps, and fill them as appropriate.

You can take it or leave it, of course! If I've missed part of your intent, let me know. 
